### PR TITLE
Add anims 2

### DIFF
--- a/BlenderExtensions/SettingsPanel.py
+++ b/BlenderExtensions/SettingsPanel.py
@@ -79,8 +79,19 @@ class AnimationsPanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
+        nmsdk_settings = context.scene.nmsdk_settings
+        if nmsdk_settings.anims_loaded is False:
+            if context.scene['_loadable_anim_names'] != []:
+                # In this case, have a menu to allow for the animations to be
+                # loaded
+                layout.operator_menu_enum('nmsdk._load_animation',
+                                          'anim_names',
+                                          text='Add an animation')
         try:
-            if context.scene['_anim_names'] == []:
+            anim_names = context.scene['_anim_names']
+            if not isinstance(anim_names, list):
+                anim_names = context.scene['_anim_names'].to_list()
+            if anim_names == list():
                 layout.label(text="No loaded animations")
             else:
                 try:

--- a/BlenderExtensions/SettingsPanel.py
+++ b/BlenderExtensions/SettingsPanel.py
@@ -79,45 +79,35 @@ class AnimationsPanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        nmsdk_settings = context.scene.nmsdk_settings
-        if nmsdk_settings.anims_loaded is False:
-            if context.scene['_loadable_anim_names'] != []:
+        anim_data = context.scene.nmsdk_anim_data
+        if anim_data.anims_loaded is False:
+            if len(anim_data.loadable_anim_data) != 0:
                 # In this case, have a menu to allow for the animations to be
                 # loaded
                 layout.operator_menu_enum('nmsdk._load_animation',
-                                          'anim_names',
+                                          'loadable_anim_name',
                                           text='Add an animation')
-        try:
-            anim_names = context.scene['_anim_names']
-            if not isinstance(anim_names, list):
-                anim_names = context.scene['_anim_names'].to_list()
-            if anim_names == list():
-                layout.label(text="No loaded animations")
-            else:
-                try:
-                    anim_choice_text = 'Current animation: {0}'.format(
-                        context.scene['curr_anim'])
-                except KeyError:
-                    anim_choice_text = 'Select an animation'
-                layout.operator_menu_enum("nmsdk._change_animation",
-                                          "anim_names",
-                                          text=anim_choice_text)
-                """
-                try:
-                    layout.label(text="Current animation: {0}".format(
-                        context.scene['curr_anim']))
-                except KeyError:
-                    layout.label(text="No animation currently selected")
-                """
-                row = layout.row()
-                row.operator("nmsdk._play_animation",
-                             icon='PLAY', emboss=False)
-                row.operator("nmsdk._pause_animation",
-                             icon='PAUSE', emboss=False)
-                row.operator("nmsdk._stop_animation",
-                             icon='REW', emboss=False)
-        except KeyError:
+        anim_names = anim_data.loaded_anims
+        if not isinstance(anim_names, list):
+            anim_names = anim_data.loaded_anims.to_list()
+        if anim_names == ['None']:
             layout.label(text="No loaded animations")
+        else:
+            try:
+                anim_choice_text = 'Current animation: {0}'.format(
+                    context.scene['curr_anim'])
+            except KeyError:
+                anim_choice_text = 'Select an animation'
+            layout.operator_menu_enum("nmsdk._change_animation",
+                                      "anim_names",
+                                      text=anim_choice_text)
+            row = layout.row()
+            row.operator("nmsdk._play_animation",
+                         icon='PLAY', emboss=False)
+            row.operator("nmsdk._pause_animation",
+                         icon='PAUSE', emboss=False)
+            row.operator("nmsdk._stop_animation",
+                         icon='REW', emboss=False)
 
 
 class SettingsPanels():

--- a/ModelExporter/addon_script.py
+++ b/ModelExporter/addon_script.py
@@ -246,6 +246,8 @@ class Exporter():
                    anim,
                    descriptor)
 
+        self.assign_anim_data()
+
         self.global_scene.frame_set(0)
 
         self.state = 'FINISHED'
@@ -999,7 +1001,7 @@ class Exporter():
     def process_anims(self):
         # get all the data. We will then consider number of actions globally
         # and process the entity stuff accordingly
-        anim_loops = dict()
+        self.anim_loops = dict()
         for anim_name in self.animation_anim_data:
             print("processing anim {}".format(anim_name))
             action_data = dict()
@@ -1020,7 +1022,7 @@ class Exporter():
                 # requisite key.
                 action_data[jnt_action[0]] = list()
                 # set whether or not the animation is to loop
-                anim_loops[anim_name] = self.global_scene.objects[
+                self.anim_loops[anim_name] = self.global_scene.objects[
                     jnt_action[0]].NMSAnimation_props.anim_loops_choice
 
             # Let's hope none of the anims have different amounts of frames...
@@ -1060,6 +1062,8 @@ class Exporter():
             # particular action
             self.anim_frame_data[anim_name] = action_data
             self.anim_node_data[anim_name] = nodes_with_anim
+
+    def assign_anim_data(self):
         # now semi-process the animation data to generate data for the
         # animation controller entity file
         if len(self.anim_frame_data) == 1:
@@ -1067,7 +1071,8 @@ class Exporter():
             path = os.path.join(self.basepath, self.group_name.upper(),
                                 self.export_name.upper())
             anim_entity = TkAnimationComponentData(
-                Idle=TkAnimationData(AnimType=list(anim_loops.values())[0]))
+                Idle=TkAnimationData(
+                    AnimType=list(self.anim_loops.values())[0]))
             # update the entity data directly
             self.anim_controller_obj[1].ExtraEntityData[
                 self.anim_controller_obj[0]].append(anim_entity)

--- a/ModelExporter/addon_script.py
+++ b/ModelExporter/addon_script.py
@@ -20,7 +20,7 @@ from ..NMS.classes import (TkMaterialData, TkMaterialFlags,
 # Animation objects
 from ..NMS.classes import (TkAnimMetadata, TkAnimNodeData, TkAnimNodeFrameData)
 from ..NMS.classes import TkAnimationComponentData, TkAnimationData
-from ..NMS.classes import List, Vector4f
+from ..NMS.classes import List, Vector4f, Quaternion
 from ..NMS.classes import TkAttachmentData
 # Object Classes
 from ..NMS.classes import (Model, Mesh, Locator, Reference, Collision, Light,
@@ -494,10 +494,10 @@ class Exporter():
                                                          t=1.0))
                         elif i == 1:
                             rot = action_data[node][frame][1]
-                            Rotations.append(Vector4f(x=rot.x,
-                                                      y=rot.y,
-                                                      z=rot.z,
-                                                      t=rot.w))
+                            Rotations.append(Quaternion(x=rot.x,
+                                                        y=rot.y,
+                                                        z=rot.z,
+                                                        w=rot.w))
                         elif i == 2:
                             scale = action_data[node][frame][2]
                             Scales.append(Vector4f(x=scale.x,
@@ -520,10 +520,10 @@ class Exporter():
                                                           t=1.0))
                     elif i == 1:
                         rot = action_data[node][0][1]
-                        stillRotations.append(Vector4f(x=rot.x,
-                                                       y=rot.y,
-                                                       z=rot.z,
-                                                       t=rot.w))
+                        stillRotations.append(Quaternion(x=rot.x,
+                                                         y=rot.y,
+                                                         z=rot.z,
+                                                         w=rot.w))
                     elif i == 2:
                         scale = action_data[node][0][2]
                         stillScales.append(Vector4f(x=scale.x,
@@ -722,7 +722,7 @@ class Exporter():
 
         # get the objects' location and convert to NMS coordinates
         trans, rot_q, scale = transform_to_NMS_coords(ob)
-        rot = rot_q.to_euler()
+        rot = rot_q.to_euler()      # TODO: should be 'ZXY'??
 
         transform = TkTransformData(TransX=trans[0],
                                     TransY=trans[1],

--- a/ModelExporter/export.py
+++ b/ModelExporter/export.py
@@ -497,9 +497,7 @@ class Export():
                 elif obj._Type == 'MODEL':
                     obj.Name = self.path
                     data = {'GEOMETRY': str(self.path) + ".GEOMETRY.MBIN"}
-                elif obj._Type == 'REFERENCE':
-                    data = None
-                elif obj._Type == 'LIGHT':
+                elif obj._Type in ['REFERENCE', 'LIGHT', 'JOINT']:
                     data = None
             obj.create_attributes(data)
 

--- a/ModelImporter/SceneNodeData.py
+++ b/ModelImporter/SceneNodeData.py
@@ -17,11 +17,11 @@ class SceneNodeData():
 
 # region public methods
 
-    def Attribute(self, name):
+    def Attribute(self, name, astype=str):
         # Doesn't support AltID's
         for attrib in self.info['Attributes']:
             if attrib['Name'] == name:
-                return attrib['Value']
+                return astype(attrib['Value'])
 
     def iter(self):
         """ Returns an ordered iterable list of SceneNodeData objects. """

--- a/ModelImporter/animation_handler.py
+++ b/ModelImporter/animation_handler.py
@@ -1,0 +1,324 @@
+# stdlib imports
+from collections import OrderedDict as odict
+from collections import namedtuple
+
+# Blender imports
+import bpy  # pylint: disable=import-error
+from bpy.props import StringProperty, BoolProperty  # noqa pylint: disable=import-error, no-name-in-module
+from mathutils import Matrix, Vector, Quaternion  # noqa pylint: disable=import-error
+
+# Internal imports
+from .readers import read_entity, read_anim  # noqa pylint: disable=relative-beyond-top-level
+from ..utils.io import get_NMS_dir  # noqa pylint: disable=relative-beyond-top-level
+
+
+DATA_PATH_MAP = {'Rotation': 'rotation_quaternion',
+                 'Translation': 'location',
+                 'Scale': 'scale'}
+
+
+class AnimationHandler(bpy.types.Operator):
+    """ Animation handler class
+
+    Parameters
+    ----------
+    context : ImportScene object
+        The class that is used to load a particular scene.
+        Because this object contains so much information regarding the loaded
+        scene it is easiest to just store a reference to this class and
+        retrieve the properties required when needed.
+    """
+
+    bl_idname = "nmsdk.animation_handler"
+    bl_label = "Main operator to handle loading of animations for NMSDK"
+
+    anim_name = StringProperty(default="")
+    anim_path = StringProperty(default="")
+
+    def execute(self, context):
+        print('Adding {0}'.format(self.anim_name))
+        self.scn = bpy.context.scene
+        self.anim_data = read_anim(self.anim_path)
+        self._add_animation_to_scene(self.anim_name, self.anim_data)
+        self.scn.nmsdk_anim_data.loaded_anims.append(self.anim_name)
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return self.execute(context)
+
+    def _add_animation_to_scene(self, anim_name, anim_data):
+        # First, let's find out what animation data each object has
+        # We do this by looking at the indexes of the rotation, translation and
+        # scale data and see whether that lies within the AnimNodeData or the
+        # StillFrameData
+        node_data_map = odict()
+        rot_anim_len = len(anim_data['AnimFrameData'][0]['Rotation'])
+        trans_anim_len = len(anim_data['AnimFrameData'][0]['Translation'])
+        scale_anim_len = len(anim_data['AnimFrameData'][0]['Scale'])
+        for node_data in anim_data['NodeData']:
+            data = {'anim': dict(), 'still': dict()}
+            # For each node, check to see if the data is in the animation data
+            # or in the still frame data
+            rotIndex = int(node_data['RotIndex'])
+            if rotIndex >= rot_anim_len:
+                rotIndex -= rot_anim_len
+                data['still']['Rotation'] = rotIndex
+            else:
+                data['anim']['Rotation'] = rotIndex
+            transIndex = int(node_data['TransIndex'])
+            if transIndex >= trans_anim_len:
+                transIndex -= trans_anim_len
+                data['still']['Translation'] = transIndex
+            else:
+                data['anim']['Translation'] = transIndex
+            scaleIndex = int(node_data['ScaleIndex'])
+            if scaleIndex >= scale_anim_len:
+                scaleIndex -= scale_anim_len
+                data['still']['Scale'] = scaleIndex
+            else:
+                data['anim']['Scale'] = scaleIndex
+            node_data_map[node_data['Node']] = data
+
+        # Now that we have all the indexes sorted out, for each node, we create
+        # a new action and give it all the information it requires.
+        for name, data in node_data_map.items():
+            try:
+                obj = self.scn.objects[name]
+            except KeyError:
+                continue
+
+            obj.animation_data_create()
+            action_name = "{0}_{1}".format(anim_name, name)
+            obj.animation_data.action = bpy.data.actions.new(
+                name=action_name)
+            # set the action to have a fake user
+            obj.animation_data.action.use_fake_user = True
+            fcurves = self._create_anim_channels(obj, action_name)
+            self._apply_animdata_to_fcurves(fcurves, data, anim_data, False)
+
+        # If we have a mesh with joint bindings, also animate the armature
+        if self.scn.nmsdk_anim_data.has_bound_mesh:
+            armature = bpy.data.objects['Armature']
+            armature.animation_data_create()
+            action_name = "{0}_Armature".format(anim_name)
+            armature.animation_data.action = bpy.data.actions.new(
+                name=action_name)
+            # set the action to have a fake user
+            armature.animation_data.action.use_fake_user = True
+            num_frames = anim_data['FrameCount']
+            for name, node_data in node_data_map.items():
+                # we only care about animating the joints
+                if name not in self.scn.nmsdk_anim_data.joints:
+                    continue
+                print('-- adding {0} --'.format(name))
+
+                bone = armature.pose.bones[name]
+
+                still_data = node_data['still']
+                animated_data = node_data['anim']
+
+                location = None
+                rotation = None
+                scale = None
+
+                # Apply the transforms as required
+                for key, value in still_data.items():
+                    data = anim_data['StillFrameData'][key][value]
+                    if key == 'Translation':
+                        location = Vector(data[:3])
+                    elif key == 'Rotation':
+                        # move the w value to the start to initialize the
+                        # quaternion
+                        rotation = Quaternion([data[3], data[0], data[1],
+                                               data[2]])
+                    elif key == 'Scale':
+                        scale = Vector(data[:3])
+
+                # Apply the proper animated data
+                # bone_ref_mat = bone.matrix.copy()
+                for i, frame in enumerate(anim_data['AnimFrameData']):
+                    # First apply the required transforms
+                    for key, value in animated_data.items():
+                        data = frame[key][value]
+                        if key == 'Translation':
+                            location = Vector(data[:3])
+                        elif key == 'Rotation':
+                            # move the w value to the start to initialize the
+                            # quaternion
+                            rotation = Quaternion([data[3], data[0], data[1],
+                                                   data[2]])
+                        elif key == 'Scale':
+                            scale = Vector(data[:3])
+
+                    bind_data = self.scn.objects[name]['bind_data']
+                    delta_loc = location - Vector(bind_data[0].to_list())
+                    delta_rot = rotation.rotation_difference(
+                        Quaternion(bind_data[1].to_list()))
+                    ref_scale = Vector(bind_data[2].to_list())
+                    delta_sca = Vector((scale[0]/ref_scale[0],
+                                        scale[1]/ref_scale[1],
+                                        scale[2]/ref_scale[2]))
+
+                    bone.location = delta_loc
+                    bone.rotation_quaternion = delta_rot
+                    bone.scale = delta_sca
+                    # For each transform applied, add a keyframe
+                    for key in ['Translation', 'Rotation', 'Scale']:
+                        if key in still_data:
+                            if i == 0 or i == num_frames - 1:
+                                self._apply_pose_data(bone, DATA_PATH_MAP[key],
+                                                      i, action_name)
+                        elif key in animated_data:
+                            self._apply_pose_data(bone, DATA_PATH_MAP[key],
+                                                  i, action_name)
+
+    def _apply_animdata_to_fcurves(self, fcurves, mapping, anim_data,
+                                   use_null_transform):
+        """ Apply the supplied animation data to the fcurves.
+
+        Parameters
+        ----------
+        fcurves : tuple of namedtuples.
+            A Tuple containing the location, rotation and scaling nameduples.
+        mapping : dict
+            Information describing what components are still frame and which
+            are animated.
+        anim_data : dict
+            The actual animation data
+        use_null_transform : bool
+            If true, then the joints shouldn't be animated as there are bones
+            which will provide the animation data.
+        """
+        loc, rot, sca = fcurves
+        num_frames = anim_data['FrameCount']
+        # If we are using the null transforms, just make all animations still
+        # frame.
+        if use_null_transform:
+            self._apply_stillframe_data(loc.x, 0, num_frames)
+            self._apply_stillframe_data(loc.y, 0, num_frames)
+            self._apply_stillframe_data(loc.z, 0, num_frames)
+            self._apply_stillframe_data(rot.x, 0, num_frames)
+            self._apply_stillframe_data(rot.y, 0, num_frames)
+            self._apply_stillframe_data(rot.z, 0, num_frames)
+            self._apply_stillframe_data(rot.w, 1, num_frames)
+            self._apply_stillframe_data(sca.x, 1, num_frames)
+            self._apply_stillframe_data(sca.y, 1, num_frames)
+            self._apply_stillframe_data(sca.z, 1, num_frames)
+            return
+        # Apply still frame data first.
+        still_data = mapping['still']
+        for key, value in still_data.items():
+            data = anim_data['StillFrameData'][key][value]
+            if key == 'Translation':
+                self._apply_stillframe_data(loc.x, data[0], num_frames)
+                self._apply_stillframe_data(loc.y, data[1], num_frames)
+                self._apply_stillframe_data(loc.z, data[2], num_frames)
+            elif key == 'Rotation':
+                self._apply_stillframe_data(rot.x, data[0], num_frames)
+                self._apply_stillframe_data(rot.y, data[1], num_frames)
+                self._apply_stillframe_data(rot.z, data[2], num_frames)
+                self._apply_stillframe_data(rot.w, data[3], num_frames)
+            elif key == 'Scale':
+                self._apply_stillframe_data(sca.x, data[0], num_frames)
+                self._apply_stillframe_data(sca.y, data[1], num_frames)
+                self._apply_stillframe_data(sca.z, data[2], num_frames)
+        animated_data = mapping['anim']
+        for key, value in animated_data.items():
+            if key == 'Translation':
+                loc.x.keyframe_points.add(num_frames)
+                loc.y.keyframe_points.add(num_frames)
+                loc.z.keyframe_points.add(num_frames)
+            elif key == 'Rotation':
+                rot.x.keyframe_points.add(num_frames)
+                rot.y.keyframe_points.add(num_frames)
+                rot.z.keyframe_points.add(num_frames)
+                rot.w.keyframe_points.add(num_frames)
+            elif key == 'Scale':
+                sca.x.keyframe_points.add(num_frames)
+                sca.y.keyframe_points.add(num_frames)
+                sca.z.keyframe_points.add(num_frames)
+            for i, frame in enumerate(anim_data['AnimFrameData']):
+                data = frame[key][value]
+                if key == 'Translation':
+                    self._apply_animframe_data(loc.x, data[0], i)
+                    self._apply_animframe_data(loc.y, data[1], i)
+                    self._apply_animframe_data(loc.z, data[2], i)
+                elif key == 'Rotation':
+                    self._apply_animframe_data(rot.x, data[0], i)
+                    self._apply_animframe_data(rot.y, data[1], i)
+                    self._apply_animframe_data(rot.z, data[2], i)
+                    self._apply_animframe_data(rot.w, data[3], i)
+                elif key == 'Scale':
+                    self._apply_animframe_data(sca.x, data[0], i)
+                    self._apply_animframe_data(sca.y, data[1], i)
+                    self._apply_animframe_data(sca.z, data[2], i)
+
+    def _apply_animframe_data(self, fcurve, data, frame):
+        fcurve.keyframe_points[int(frame)].co = float(frame), float(data)
+
+    def _apply_stillframe_data(self, fcurve, data, num_frame):
+        fcurve.keyframe_points.add(2)
+        fcurve.keyframe_points[0].co = 0.0, float(data)
+        fcurve.keyframe_points[0].interpolation = 'CONSTANT'
+        fcurve.keyframe_points[1].co = float(num_frame - 1), float(data)
+        fcurve.keyframe_points[1].interpolation = 'CONSTANT'
+
+    def _apply_pose_data(self, bone, _type, frame, name):
+        bone.keyframe_insert(data_path=_type, frame=frame, group=name)
+
+    def _create_anim_channels(self, obj, anim_name):
+        """ Generate all the channels required for the animation.
+
+        Parameters
+        ----------
+        obj : Blender object
+            The object to create the anim channels on.
+        anim_name : str
+            Name of the animation so that all fcurves are in the same group.
+
+        Returns
+        -------
+        Tuple of collections.namedtuple's:
+            (location, rotation, scale)
+        """
+        location = namedtuple('location', ['x', 'y', 'z'])
+        rotation = namedtuple('rotation', ['x', 'y', 'z', 'w'])
+        scale = namedtuple('scale', ['x', 'y', 'z'])
+        loc_x = obj.animation_data.action.fcurves.new(data_path='location',
+                                                      index=0,
+                                                      action_group=anim_name)
+        loc_y = obj.animation_data.action.fcurves.new(data_path='location',
+                                                      index=1,
+                                                      action_group=anim_name)
+        loc_z = obj.animation_data.action.fcurves.new(data_path='location',
+                                                      index=2,
+                                                      action_group=anim_name)
+        loc = location(loc_x, loc_y, loc_z)
+        rot_w = obj.animation_data.action.fcurves.new(
+            data_path='rotation_quaternion',
+            index=0,
+            action_group=anim_name)
+        rot_x = obj.animation_data.action.fcurves.new(
+            data_path='rotation_quaternion',
+            index=1,
+            action_group=anim_name)
+        rot_y = obj.animation_data.action.fcurves.new(
+            data_path='rotation_quaternion',
+            index=2,
+            action_group=anim_name)
+        rot_z = obj.animation_data.action.fcurves.new(
+            data_path='rotation_quaternion',
+            index=3,
+            action_group=anim_name)
+        rot = rotation(rot_x, rot_y, rot_z, rot_w)
+        sca_x = obj.animation_data.action.fcurves.new(data_path='scale',
+                                                      index=0,
+                                                      action_group=anim_name)
+        sca_y = obj.animation_data.action.fcurves.new(data_path='scale',
+                                                      index=1,
+                                                      action_group=anim_name)
+        sca_z = obj.animation_data.action.fcurves.new(data_path='scale',
+                                                      index=2,
+                                                      action_group=anim_name)
+        sca = scale(sca_x, sca_y, sca_z)
+        return (loc, rot, sca)

--- a/ModelImporter/readers.py
+++ b/ModelImporter/readers.py
@@ -92,16 +92,7 @@ def read_entity(fname):
         animation data.
     """
 
-    def read_TkAnimationComponentData(f):
-        data = dict()
-        # Read the anim name and path into the data dictionary
-        data['Anim'] = read_string(f, 0x10)
-        data['Filename'] = read_string(f, 0x80)
-        # Move the pointer to the end of the TkAnimationComponentData struct
-        f.seek(0xA8, 1)
-        return data
-
-    anim_data = list()
+    anim_data = dict()
     with open(fname, 'rb') as f:
         f.seek(0x60)
         has_anims = False
@@ -120,10 +111,12 @@ def read_entity(fname):
             return anim_data
         # Jump to the start of the struct
         f.seek(return_offset + offset)
-        anim_data.append(read_TkAnimationComponentData(f))
+        _anim_data = read_TkAnimationComponentData(f)
+        anim_data[_anim_data.pop('Anim')] = _anim_data
         with ListHeader(f) as anims:
             for _ in range(anims.count):
-                anim_data.append(read_TkAnimationComponentData(f))
+                _anim_data = read_TkAnimationComponentData(f)
+                anim_data[_anim_data.pop('Anim')] = _anim_data
         return anim_data
 
 
@@ -273,3 +266,13 @@ def read_gstream(fname, info):
         f.seek(info.idx_off)
         indexes = f.read(info.idx_size)
     return verts, indexes
+
+
+def read_TkAnimationComponentData(f):
+    """ Extract the animation name and path from the entity file. """
+    data = dict()
+    data['Anim'] = read_string(f, 0x10)
+    data['Filename'] = read_string(f, 0x80)
+    # Move the pointer to the end of the TkAnimationComponentData struct
+    f.seek(0xA8, 1)
+    return data

--- a/NMS/classes/Quaternion.py
+++ b/NMS/classes/Quaternion.py
@@ -1,0 +1,22 @@
+# Quaternion struct
+
+from .Struct import Struct
+from ...serialization.formats import write_int_2_10_10_10_rev
+
+
+class Quaternion(Struct):
+    def __init__(self, **kwargs):
+        super(Quaternion, self).__init__()
+
+        """ Contents of the struct """
+        self.data['x'] = kwargs.get('x', 0.0)
+        self.data['y'] = kwargs.get('y', 0.0)
+        self.data['z'] = kwargs.get('z', 0.0)
+        self.data['w'] = kwargs.get('w', 0.0)
+        """ End of the struct contents"""
+
+    def __bytes__(self):
+        return write_int_2_10_10_10_rev([self.data['x'],
+                                         self.data['y'],
+                                         self.data['z'],
+                                         self.data['w']])

--- a/NMS/classes/TkAnimNodeData.py
+++ b/NMS/classes/TkAnimNodeData.py
@@ -11,7 +11,7 @@ class TkAnimNodeData(Struct):
         """ Contents of the struct """
         self.data['Node'] = String(kwargs.get('Node', ""), 0x10)
         # String(chr(0xFE)*4, 4))
-        self.data['CanCompress'] = kwargs.get('CanCompress', False)
+        self.data['CanCompress'] = kwargs.get('CanCompress', True)
         self.data['RotIndex'] = kwargs.get('RotIndex', 0)
         self.data['TransIndex'] = kwargs.get('TransIndex', 0)
         self.data['ScaleIndex'] = kwargs.get('ScaleIndex', 0)

--- a/NMS/classes/__init__.py
+++ b/NMS/classes/__init__.py
@@ -7,9 +7,11 @@ from .Empty import Empty  # noqa
 from .Object import (Locator, Light, Mesh, Joint, Emitter, Collision, Model,  # noqa
                      Reference)
 from .Vector4f import Vector4f  # noqa
+from .Quaternion import Quaternion  # noqa
 from .NMSString0x10 import NMSString0x10  # noqa
 from .NMSString0x20 import NMSString0x20  # noqa
 from .NMSString0x80 import NMSString0x80  # noqa
+
 from .TkAttachmentData import TkAttachmentData  # noqa
 from .TkVertexLayout import TkVertexLayout  # noqa
 from .TkVertexElement import TkVertexElement  # noqa

--- a/NMSDK.py
+++ b/NMSDK.py
@@ -118,8 +118,8 @@ class _ChangeAnimation(Operator):
         """
         context.scene['curr_anim'] = self.anim_names
         frame_count = 0
+        # Apply the action to each object
         for obj in context.scene.objects:
-            # Generate the action name
             action_name = '{0}_{1}'.format(self.anim_names, obj.name)
             if action_name in bpy.data.actions:
                 obj.animation_data.action = bpy.data.actions[action_name]
@@ -132,6 +132,14 @@ class _ChangeAnimation(Operator):
                 except AttributeError:
                     # Some objects in the scene may not have animation data
                     continue
+        if self.anim_names == 'None':
+            for armature in bpy.data.armatures:
+                armature.pose_position = 'REST'
+        else:
+            for armature in bpy.data.armatures:
+                armature.pose_position = 'POSE'
+
+        # Set the final frame count
         context.scene.frame_end = frame_count
         return {'FINISHED'}
 

--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,7 @@ from .NMSDK import (_FixOldFormat, _ToggleCollisionVisibility,
 from .NMSDK import NMSDKSettings, NMSDKDefaultSettings
 # Animation classes
 from .NMSDK import (_ChangeAnimation, _PlayAnimation, _PauseAnimation,
-                    _StopAnimation)
+                    _StopAnimation, _LoadAnimation)
 
 customNodes = NMSNodes()
 
@@ -53,6 +53,7 @@ def register():
     bpy.utils.register_class(_ToggleCollisionVisibility)
     bpy.utils.register_class(_SaveDefaultSettings)
     bpy.utils.register_class(_ChangeAnimation)
+    bpy.utils.register_class(_LoadAnimation)
     bpy.utils.register_class(_PlayAnimation)
     bpy.utils.register_class(_PauseAnimation)
     bpy.utils.register_class(_StopAnimation)
@@ -79,6 +80,7 @@ def unregister():
     bpy.utils.unregister_class(_ToggleCollisionVisibility)
     bpy.utils.unregister_class(_SaveDefaultSettings)
     bpy.utils.unregister_class(_ChangeAnimation)
+    bpy.utils.unregister_class(_LoadAnimation)
     bpy.utils.unregister_class(_PlayAnimation)
     bpy.utils.unregister_class(_PauseAnimation)
     bpy.utils.unregister_class(_StopAnimation)

--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,8 @@ from .NMSDK import (_FixOldFormat, _ToggleCollisionVisibility,
 from .NMSDK import NMSDKSettings, NMSDKDefaultSettings
 # Animation classes
 from .NMSDK import (_ChangeAnimation, _PlayAnimation, _PauseAnimation,
-                    _StopAnimation, _LoadAnimation)
+                    _StopAnimation, _LoadAnimation, AnimProperties)
+from .ModelImporter.animation_handler import AnimationHandler
 
 customNodes = NMSNodes()
 
@@ -57,9 +58,12 @@ def register():
     bpy.utils.register_class(_PlayAnimation)
     bpy.utils.register_class(_PauseAnimation)
     bpy.utils.register_class(_StopAnimation)
+    bpy.utils.register_class(AnimationHandler)
+    bpy.utils.register_class(AnimProperties)
     bpy.types.Scene.nmsdk_settings = PointerProperty(type=NMSDKSettings)
     bpy.types.Scene.nmsdk_default_settings = PointerProperty(
         type=NMSDKDefaultSettings)
+    bpy.types.Scene.nmsdk_anim_data = PointerProperty(type=AnimProperties)
     bpy.types.INFO_MT_file_export.append(menu_func_export)
     bpy.types.INFO_MT_file_import.append(menu_func_import)
     NMSPanels.register()
@@ -84,9 +88,11 @@ def unregister():
     bpy.utils.unregister_class(_PlayAnimation)
     bpy.utils.unregister_class(_PauseAnimation)
     bpy.utils.unregister_class(_StopAnimation)
+    bpy.utils.unregister_class(AnimationHandler)
+    bpy.utils.unregister_class(AnimProperties)
     del bpy.types.Scene.nmsdk_settings
     del bpy.types.Scene.nmsdk_default_settings
-    del bpy.types.Scene.anim_names
+    del bpy.types.Scene.anim_data
     bpy.types.INFO_MT_file_export.remove(menu_func_export)
     bpy.types.INFO_MT_file_import.remove(menu_func_import)
     NMSPanels.unregister()

--- a/serialization/formats/INT_2_10_10_10_REV.py
+++ b/serialization/formats/INT_2_10_10_10_REV.py
@@ -32,12 +32,6 @@ def twos_complement(input_value, num_bits):
     return -(input_value & mask) + (input_value & ~mask)
 
 
-"""def bin_to_signed_int(b):
-    # this will take a binary number and return the signed int of it
-    sgn = b >> 9    # this the most significant bit
-    if sgn == 1:"""
-
-
 def write_int_2_10_10_10_rev(verts):
     """
     writes the verts to a INT_2_10_10_10_REV

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -15,8 +15,21 @@ def CompareMatrices(mat1, mat2, tol):
 
 def ContinuousCompare(lst, tol):
     """
-    Takes a list of tuples, and each element is compared to the next one
-    Any tuple that changes has the index of it returned
+    Takes a list of tuples, and each element is compared to the next one.
+    Any tuple that changes has the index of it returned.
+
+    Parameters
+    ----------
+    lst : list of tuples
+        A list of tuples which are animation data.
+    tol : float
+        The minimum difference between two consecutive values before they are
+        considered different.
+
+    Returns
+    -------
+    changing_indices : set
+        The indexes that of the components of the tuple that change.
     """
     changing_indices = set()
     last_tup = None


### PR DESCRIPTION
Bring in a number of changes relating to animations:
 - Animation importing has been moved to an operator so that it can be used by both the automatic importer, as well as in the NMSDK panel so that scenes with a lot of animations can have their animations loaded separately
- A number of fixes have been made regarding exporting animations so that they work better now/are compatible with the current version of MBINCompiler (which transitioned to using `Quaternion`s for the rotation component of the animation data.