### PR TITLE
Install and run Pytest from within Blender

### DIFF
--- a/BlenderExtensions/SettingsPanel.py
+++ b/BlenderExtensions/SettingsPanel.py
@@ -86,6 +86,30 @@ class NMSDK_PT_DefaultsPanel(bpy.types.Panel):
         layout.operator("nmsdk._save_default_settings", icon='FILE_TICK',
                         text='Save settings')
 
+class NMSDK_PT_TestsPanel(bpy.types.Panel):
+    bl_idname = 'NMSDK_PT_TestsPanel'
+    bl_label = 'Tests'
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'NMSDK'
+    bl_context = 'objectmode'
+    
+    @classmethod
+    def poll(self, context):
+        return True
+
+    def draw(self, context):
+        layout = self.layout
+        try:
+            import pytest
+            row = layout.row(align=True)
+            row.alignment = 'LEFT'
+            row.prop( context.scene.nmsdk_tests, "tests", text="")
+            row.operator("nmsdk.run_test",text="",
+                         icon='PLAY', emboss=False)
+        except ModuleNotFoundError:
+            # Blender has privilege and can install pytest
+            layout.operator("nmsdk.install_pytest")
 
 class NMSDK_PT_AnimationsPanel(bpy.types.Panel):
     bl_idname = 'NMSDK_PT_AnimationsPanel'
@@ -146,6 +170,7 @@ class NMSDK_PT_AnimationsPanel(bpy.types.Panel):
 classes = (NMSDK_PT_UpdateSettingsPanel,
            NMSDK_PT_ToolsPanel,
            NMSDK_PT_DefaultsPanel,
+           NMSDK_PT_TestsPanel,
            NMSDK_PT_AnimationsPanel)
 
 

--- a/BlenderExtensions/SettingsPanel.py
+++ b/BlenderExtensions/SettingsPanel.py
@@ -93,7 +93,7 @@ class NMSDK_PT_TestsPanel(bpy.types.Panel):
     bl_region_type = 'UI'
     bl_category = 'NMSDK'
     bl_context = 'objectmode'
-    
+
     @classmethod
     def poll(self, context):
         return True
@@ -104,8 +104,8 @@ class NMSDK_PT_TestsPanel(bpy.types.Panel):
             import pytest
             row = layout.row(align=True)
             row.alignment = 'LEFT'
-            row.prop( context.scene.nmsdk_tests, "tests", text="")
-            row.operator("nmsdk.run_test",text="",
+            row.prop(context.scene.nmsdk_tests, "tests", text="")
+            row.operator("nmsdk.run_test", text="",
                          icon='PLAY', emboss=False)
         except ModuleNotFoundError:
             # Blender has privilege and can install pytest

--- a/__init__.py
+++ b/__init__.py
@@ -33,6 +33,8 @@ from .NMSDK import (_ChangeAnimation, _PlayAnimation, _PauseAnimation,
                     _StopAnimation, _LoadAnimation, AnimProperties,
                     _RefreshAnimations)
 from .ModelImporter.animation_handler import AnimationHandler
+# Tests
+from .pytest import (NMSTests, RunTest, InstallPytest)
 # extensions to blender UI
 from .BlenderExtensions import (NMSNodes, NMSEntities, NMSPanels,
                                 SettingsPanels, ContextMenus)  # , NMSShaderNode)
@@ -77,7 +79,11 @@ classes = (NMS_Export_Operator,
            _PauseAnimation,
            _StopAnimation,
            AnimationHandler,
-           AnimProperties)
+           AnimProperties,
+           NMSTests,
+           RunTest,
+           InstallPytest
+          )
 
 
 def register():
@@ -87,6 +93,7 @@ def register():
     bpy.types.Scene.nmsdk_default_settings = PointerProperty(
         type=NMSDKDefaultSettings)
     bpy.types.Scene.nmsdk_anim_data = PointerProperty(type=AnimProperties)
+    bpy.types.Scene.nmsdk_tests = PointerProperty(type=NMSTests)
     bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
     NMSPanels.register()
@@ -103,6 +110,7 @@ def unregister():
     del bpy.types.Scene.nmsdk_settings
     del bpy.types.Scene.nmsdk_default_settings
     del bpy.types.Scene.anim_data
+    del bpy.types.Scene.nmsdk_tests
     bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
     NMSPanels.unregister()

--- a/pytest.py
+++ b/pytest.py
@@ -1,0 +1,61 @@
+# Test NMSDK
+from bpy.types import (Operator,PropertyGroup)
+from bpy.props import EnumProperty
+import os
+import subprocess
+import ensurepip
+import bpy
+
+class NMSTests(PropertyGroup):
+
+    tests: EnumProperty(
+        name='Available tests',
+        description='List of all available tests',
+        items=[ 
+            ( '\\tests\\import_tests\\import_crystal.py', 'Import large crystal', '' ),
+            ( '\\tests\\import_tests\\import_toycube.py', 'Import toy cube','' ),
+    ])
+
+class RunTest(Operator):
+    """Run a test"""
+    bl_idname = "nmsdk.run_test"
+    bl_label = "Run test"
+
+    def execute(self, context):
+        try:
+            import pytest
+            print("enum state:",context.scene.nmsdk_tests.tests)
+            print(os.path.dirname(__file__))
+            pytest.main([os.path.dirname(__file__)+context.scene.nmsdk_tests.tests])
+#import sys
+#sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+#import sample
+#            
+            return {'FINISHED'}
+        except ModuleNotFoundError:
+            print ('Pytest not installed')
+            return {'CANCELLED'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_confirm(self, event)
+
+# Pip is provided with 2.81
+# cf. https://blender.stackexchange.com/questions/139718/install-pip-and-packages-from-within-blender-os-independently
+# To uninstall pytest:
+#    -b --python-expr "import bpy; import subprocess; import ensurepip; ensurepip.bootstrap(); subprocess.check_call([bpy.app.binary_path_python, '-m', 'pip', 'uninstall', 'pytest'])"
+class InstallPytest(Operator):
+    """Install Pytest"""
+    bl_idname = "nmsdk.install_pytest"
+    bl_label = "Install Pytest"
+    
+    def execute(self, context):
+        ensurepip.bootstrap()
+        # Bootstrap modifies a necessary system variable cf. https://developer.blender.org/T71856
+        os.environ.pop("PIP_REQ_TRACKER", None)
+        subprocess.check_call([bpy.app.binary_path_python, '-m', 'pip', 'install', 'pytest'])
+        bpy.ops.script.reload()
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_confirm(self, event)

--- a/pytest.py
+++ b/pytest.py
@@ -15,9 +15,13 @@ class NMSTests(PropertyGroup):
         items=[
             ('\\tests\\import_tests\\import_crystal.py', 'Import large crystal', ''),
             ('\\tests\\import_tests\\import_toycube.py', 'Import toy cube', ''),
+            ('tests/import_tests', 'Import tests', ''),
+            ('tests/export_tests', 'Export tests', ''),
+            ('tests/import_export_tests', 'Import & export tests', ''),
+            ('serialization', 'Serialization', ''),
+            ('', 'All tests', ''),
         ]
     )
-
 class RunTest(Operator):
     """Run a test"""
     bl_idname = "nmsdk.run_test"
@@ -26,9 +30,7 @@ class RunTest(Operator):
     def execute(self, context):
         try:
             from pytest import main as pytexec
-            print("enum state:", context.scene.nmsdk_tests.tests)
-            print(os.path.dirname(__file__))
-            pytexec([os.path.dirname(__file__) + context.scene.nmsdk_tests.tests])
+            pytexec([bpy.utils.user_resource('SCRIPTS') + 'addons\\nmsdk\\' + context.scene.nmsdk_tests.tests])
             return {'FINISHED'}
         except ModuleNotFoundError:
             print('Pytest not installed')

--- a/pytest.py
+++ b/pytest.py
@@ -1,20 +1,22 @@
 # Test NMSDK
-from bpy.types import (Operator,PropertyGroup)
-from bpy.props import EnumProperty
 import os
 import subprocess
 import ensurepip
+
 import bpy
+from bpy.types import (Operator, PropertyGroup)
+from bpy.props import EnumProperty
 
 class NMSTests(PropertyGroup):
 
     tests: EnumProperty(
         name='Available tests',
         description='List of all available tests',
-        items=[ 
-            ( '\\tests\\import_tests\\import_crystal.py', 'Import large crystal', '' ),
-            ( '\\tests\\import_tests\\import_toycube.py', 'Import toy cube','' ),
-    ])
+        items=[
+            ('\\tests\\import_tests\\import_crystal.py', 'Import large crystal', ''),
+            ('\\tests\\import_tests\\import_toycube.py', 'Import toy cube', ''),
+        ]
+    )
 
 class RunTest(Operator):
     """Run a test"""
@@ -23,32 +25,28 @@ class RunTest(Operator):
 
     def execute(self, context):
         try:
-            import pytest
-            print("enum state:",context.scene.nmsdk_tests.tests)
+            from pytest import main as pytexec
+            print("enum state:", context.scene.nmsdk_tests.tests)
             print(os.path.dirname(__file__))
-            pytest.main([os.path.dirname(__file__)+context.scene.nmsdk_tests.tests])
-#import sys
-#sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-#import sample
-#            
+            pytexec([os.path.dirname(__file__) + context.scene.nmsdk_tests.tests])
             return {'FINISHED'}
         except ModuleNotFoundError:
-            print ('Pytest not installed')
+            print('Pytest not installed')
             return {'CANCELLED'}
 
     def invoke(self, context, event):
         return context.window_manager.invoke_confirm(self, event)
 
 # Pip is provided with 2.81
-# cf. https://blender.stackexchange.com/questions/139718/install-pip-and-packages-from-within-blender-os-independently
+# cf. https://blender.stackexchange.com/questions/139718/
 # To uninstall pytest:
-#    -b --python-expr "import bpy; import subprocess; import ensurepip; ensurepip.bootstrap(); subprocess.check_call([bpy.app.binary_path_python, '-m', 'pip', 'uninstall', 'pytest'])"
+#    -b --python-expr "import bpy; import subprocess; import ensurepip; ensurepip.bootstrap();
+# subprocess.check_call([bpy.app.binary_path_python, '-m', 'pip', 'uninstall', 'pytest'])"
 class InstallPytest(Operator):
     """Install Pytest"""
     bl_idname = "nmsdk.install_pytest"
     bl_label = "Install Pytest"
-    
+
     def execute(self, context):
         ensurepip.bootstrap()
         # Bootstrap modifies a necessary system variable cf. https://developer.blender.org/T71856

--- a/pytest.py
+++ b/pytest.py
@@ -13,13 +13,13 @@ class NMSTests(PropertyGroup):
         name='Available tests',
         description='List of all available tests',
         items=[
-            ('\\tests\\import_tests\\import_crystal.py', 'Import large crystal', ''),
-            ('\\tests\\import_tests\\import_toycube.py', 'Import toy cube', ''),
-            ('tests/import_tests', 'Import tests', ''),
-            ('tests/export_tests', 'Export tests', ''),
-            ('tests/import_export_tests', 'Import & export tests', ''),
-            ('serialization', 'Serialization', ''),
-            ('', 'All tests', ''),
+            ('/tests/import_tests/import_crystal.py', 'Import large crystal', ''),
+            ('/tests/import_tests/import_toycube.py', 'Import toy cube', ''),
+            ('/tests/import_tests', 'Import tests', ''),
+            ('/tests/export_tests', 'Export tests', ''),
+            ('/tests/import_export_tests', 'Import & export tests', ''),
+            ('/serialization', 'Serialization', ''),
+            ('/', 'All tests', ''),
         ]
     )
 class RunTest(Operator):
@@ -30,7 +30,7 @@ class RunTest(Operator):
     def execute(self, context):
         try:
             from pytest import main as pytexec
-            pytexec([bpy.utils.user_resource('SCRIPTS') + 'addons\\nmsdk\\' + context.scene.nmsdk_tests.tests])
+            pytexec([bpy.utils.user_resource('SCRIPTS') + 'addons\\nmsdk' + context.scene.nmsdk_tests.tests])
             return {'FINISHED'}
         except ModuleNotFoundError:
             print('Pytest not installed')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
-import pytest
+import sys
 import subprocess
+import pytest
 
 
 # TODO: create a fixture which uses the pytest fixture (?) or property which
@@ -15,7 +16,10 @@ def run_test():
     """ A fixture that is used to run each test by calling some python code
     from blender. """
     def _run_test(test_path: list, blend_path=None):
-        _blender_path = os.environ.get('BLENDERPATH')
+        if os.path.basename(sys.executable) == 'blender.exe':
+            _blender_path = sys.executable
+        else:
+            _blender_path = os.environ.get('BLENDERPATH')
         if _blender_path:
             cmd = [_blender_path, '-b', '-noaudio']
             if blend_path:


### PR DESCRIPTION
Here's a basic implementation of Pytest in Blender. This adds a new panel, and checks for Pytest. If it's not there, a user may install Pytest from Pip (Included in 2.81+)

After you install pytest, you can either run tests listed in pytest.py, pytest.ini or you can run pytest from blender commandline:
blender.exe -b --python-expr "import bpy; import pytest; pytest.main([bpy.utils.user_resource('SCRIPTS')+'addons\\nmsdk\\'])"

TODO: An add-on option to disable the tests panel

NMS gets updated frequently and breaks frequently so this makes testing available to users
