### PR TITLE
Make Blender location detection smarter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ to generate the *.mbin* files that are read by the game.
 The easiest way to have *MBINCompiler* set up is to download the most recent
 release and register *MBINCompiler* to the path so that it can be picked up
 anywhere by Blender.
-If you already have a version of *MBINCompiler* on your computer, ensure it is
-version **v2.61.1-pre1** or above. This can be found on the [MBINCompiler releases](https://github.com/monkeyman192/MBINCompiler/releases) page.
+If you already have a version of *MBINCompiler* on your computer, ensure it is the latest version. This can be found on the [MBINCompiler releases](https://github.com/monkeyman192/MBINCompiler/releases) page.
 
 For NMSDK to be able to use *MBINCompiler*, the program needs to be registered to the path so that it can be called from anywhere on your computer.
 Open the folder containing the `MBINCompiler.exe` you just downloaded, open this folder in command line, then enter `MBINCompiler.exe register`.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,7 @@ To make exporting easier, NMSDK will automatically convert all produced `.exml` 
 
 #### Blender
 
-NMSDK requires a version of blender greater than or equal to 2.79.
-This is due to the model importer component to need a shader node that only exists with Blender 2.79 and above.
-
-NMSDK has not been tested for blender 2.80, however it is likely to not work, and support for 2.80 will not come until 2.80 is out of beta and is the latest official release.
+NMSDK requires a version of blender greater than or equal to 2.80. This is due to various API changes introduced in 2.80.
 
 #### MBINCompiler
 
@@ -32,7 +29,7 @@ The easiest way to have *MBINCompiler* set up is to download the most recent
 release and register *MBINCompiler* to the path so that it can be picked up
 anywhere by Blender.
 If you already have a version of *MBINCompiler* on your computer, ensure it is
-version **v1.78.0-pre1** or above. This can be found on the [MBINCompiler releases](https://github.com/monkeyman192/MBINCompiler/releases) page.
+version **v2.61.1-pre1** or above. This can be found on the [MBINCompiler releases](https://github.com/monkeyman192/MBINCompiler/releases) page.
 
 For NMSDK to be able to use *MBINCompiler*, the program needs to be registered to the path so that it can be called from anywhere on your computer.
 Open the folder containing the `MBINCompiler.exe` you just downloaded, open this folder in command line, then enter `MBINCompiler.exe register`.
@@ -49,7 +46,7 @@ For a comprehensive guide on using NMSDK, please visit the [documentation](https
 If you are looking to develop NMSDK, there are a number of tests that can be run so ensure the added functionality doesn't cause any regressions.
 If new features are added, it is highly encouraged that new tests are written to ensure good code coverage (not currently tracked, and not even sure if it is possible to...)
 
-To run the tests, you must have NMSDK cloned from git, and not simply installed. In a console, then run
+To run the tests, you must have NMSDK cloned from git, and not simply installed. If you're using Github Desktop, you will also need Git for Windows installed to have Git Bash available. In a console, then run
 ```
 ./run_tests.sh`.
 ```
@@ -62,7 +59,7 @@ For example, to run a single individual test you could enter
 ./run_tests.sh tests/import_tests/import_test.py::test_import_crystal
 ```
 
-For more info, use `./run_tests.sh -h` to see the help and options.
+This script uses the Blender that is assigned to open .blend files - do Blender.exe -R to associate Blender with .blend files. To learn how to specify an alternative Blender executable or for more info, use `./run_tests.sh -h` to see the help and options.
 
 ### Credits
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -17,9 +17,9 @@ while getopts "p:b:hl" opt "${EXTRAS[@]}"; do
         h)
             echo -e "NMSDK test usage instructions:\n";
             echo "ARGUMENTS:";
-	    echo "-b <blender path> (optional, defaults to what opens your .blend files)"
+            echo "-b <blender path> (optional, defaults to what opens your .blend files)"
             echo -e "\tThe relative or absolute path to the blender executable.";
-	    echo "-p <python path> (optional, defaults to the Python configured in Blender)"
+            echo "-p <python path> (optional, defaults to the Python configured in Blender)"
             echo -e "\tThe relative or absolute path to the python executable.";
             echo -e "\tThis should be the executable that blender executable provided by -b uses.";
             echo "-l"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-PYTHON=../../../python/bin/python.exe;
-BLENDER=../../../../blender.exe;
+BLENDER=$( reg query "HKEY_CLASSES_ROOT\blendfile\shell\open\command" | grep 'blender' | cut -d '"' -f2 )
+PYTHON=$( "$BLENDER" -b --disable-autoexec -noaudio --factory-startup --python-expr "import bpy; import sys; print(bpy.app.binary_path_python, file=sys.stderr)" 3>&1 1>/dev/null 2>&3 )
+
 TESTS="";
 LOGGING="";
 
@@ -16,9 +17,9 @@ while getopts "p:b:hl" opt "${EXTRAS[@]}"; do
         h)
             echo -e "NMSDK test usage instructions:\n";
             echo "ARGUMENTS:";
-            echo "-b <blender path> (optional, defaults to '.../../../../blender.exe')";
-            echo -e "\tThe relative or absolue path to the blender executable.";
-            echo "-p <python path> (optional, defaults to '../../../python/bin/python.exe')";
+	    echo "-b <blender path> (optional, defaults to what opens your .blend files)"
+            echo -e "\tThe relative or absolute path to the blender executable.";
+	    echo "-p <python path> (optional, defaults to the Python configured in Blender)"
             echo -e "\tThe relative or absolute path to the python executable.";
             echo -e "\tThis should be the executable that blender executable provided by -b uses.";
             echo "-l"
@@ -41,12 +42,12 @@ if [ "$@" ]; then
     TESTS="$@";
 fi
 
-export BLENDERPATH=$(realpath $BLENDER);
+export BLENDERPATH=$(realpath "$BLENDER");
 
 # run the tests with the blender python
-if $PYTHON -m pip freeze | grep 'pytest' > /dev/null 2>&1; then
-    $PYTHON -m pytest -vv "$LOGGING" "$TESTS";
+if "$PYTHON" -m pip freeze | grep 'pytest' > /dev/null 2>&1; then
+    "$PYTHON" -m pytest -vv "$LOGGING" "$TESTS";
 else
-    $PYTHON -m pip install pytest;
-    $PYTHON -m pytest -vv "$LOGGING" "$TESTS";
+    "$PYTHON" -m pip install pytest;
+    "$PYTHON" -m pytest -vv "$LOGGING" "$TESTS";
 fi


### PR DESCRIPTION
The default Blender & Python variables weren't working for me - I have Blender in the default installation path, ie.:

%ProgramFiles%\Blender Foundation\Blender 2.83\blender.exe

NMSDK is in: %AppData%\Blender Foundation\Blender\2.83\scripts\addons\nmsdk

We should reasonably expect users to associate their .blend files.

(The default path needs to be quoted because it has spaces in it.)

You can make Blender associate .blend files with blender.exe -R