### PR TITLE
Fix bug that fails to assign the same material to multiple meshes

### DIFF
--- a/ModelImporter/import_scene.py
+++ b/ModelImporter/import_scene.py
@@ -1014,7 +1014,7 @@ class ImportScene():
                                                 self.local_root_folder)
                 if material:
                     self.materials[mat_path] = material
-            else
+            else:
                 material = self.materials[mat_path]
             mesh_obj.NMSMesh_props.material_path = scene_node.Attribute(
                 'MATERIAL')

--- a/ModelImporter/import_scene.py
+++ b/ModelImporter/import_scene.py
@@ -1014,6 +1014,8 @@ class ImportScene():
                                                 self.local_root_folder)
                 if material:
                     self.materials[mat_path] = material
+            else
+                material = self.materials[mat_path]
             mesh_obj.NMSMesh_props.material_path = scene_node.Attribute(
                 'MATERIAL')
         if material is not None:


### PR DESCRIPTION
The plugin fails to append a material to a mesh, if the material has previously been appended to a different mesh. This happens because material variable is only set in the condition that the current mat_path is not present in materials dictionary yet.

This change also assigns the material variable when the condition is false, to the material previously saved in the materials dictionary under the same mat_path.